### PR TITLE
fix(prompt): use JLENV_ROOT, JLENV_HOOK_PATH, JLENV_DIR env vars in prompt env

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -63,5 +63,5 @@ p6df::modules::jl::prompt::lang() {
 ######################################################################
 p6df::modules::julia::prompt::env() {
 
-  p6_return_words 'julia' "$"
+  p6_return_words 'julia' '$JLENV_ROOT' '$JLENV_HOOK_PATH' '$JLENV_DIR'
 }


### PR DESCRIPTION
## What
Fix `p6df::modules::julia::prompt::env` to pass `$JLENV_ROOT`, `$JLENV_HOOK_PATH`, and `$JLENV_DIR` environment variables instead of the broken `"$"` literal.

## Why
The previous value `"$"` was a broken placeholder. The correct Julia/jlenv environment variables are now referenced so the prompt env function exposes them properly.

## Test plan
- Reviewed diff; single-line fix replacing `"$"` with `'$JLENV_ROOT' '$JLENV_HOOK_PATH' '$JLENV_DIR'`
- No functional regressions expected; this fixes a non-functional placeholder

## Dependencies
None