### PR TITLE
refactor(julia): update function signatures and rename prompt::env return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,9 @@ TODO: Add a short summary of this module.
 ##### p6df-julia/init.zsh
 
 - `p6df::modules::julia::deps()`
-- `p6df::modules::julia::init(_module, dir)`
-  - Args:
-    - _module -
-    - dir -
-- `str str = p6df::modules::jl::prompt::env()`
+- `p6df::modules::julia::langmgr::init()`
 - `str str = p6df::modules::jl::prompt::lang()`
+- `words julia = p6df::modules::julia::prompt::env()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -53,12 +53,12 @@ p6df::modules::jl::prompt::lang() {
 ######################################################################
 #<
 #
-# Function: words julia $JLENV_ROOT = p6df::modules::julia::prompt::env()
+# Function: words julia = p6df::modules::julia::prompt::env()
 #
 #  Returns:
-#	words - julia $JLENV_ROOT
+#	words - julia
 #
-#  Environment:	 JLENV_ROOT
+#  Environment:	 JLENV_DIR JLENV_HOOK_PATH JLENV_ROOT
 #>
 ######################################################################
 p6df::modules::julia::prompt::env() {


### PR DESCRIPTION
**What:** Update function signatures and fix prompt::env return type declaration

**Why:** Normalizes function documentation to use consistent `words julia` return type and adds `langmgr::init`

**Test plan:** Shell loads without errors; julia prompt functions return expected values

**Dependencies:** none